### PR TITLE
冗長な変数削除

### DIFF
--- a/src/background/background.js
+++ b/src/background/background.js
@@ -4,14 +4,12 @@ const type = "normal";
 const contexts = ["selection"];
 
 let code;
-let err;
 
 chrome.runtime.onMessage.addListener(message => {
   const result = codeFormat(message.code);
   if (result.err) {
-    err = result.err;
     chrome.contextMenus.update(id, {
-      title: `${title} [Error] ${err}`,
+      title: `${title} [Error] ${result.err}`,
       enabled: false
     });
   } else {


### PR DESCRIPTION
background.jsの`result.err`を受け取る変数を用意していたが、他の所で使っていないため削除